### PR TITLE
an/info-message-styling

### DIFF
--- a/libs/solid/skeleton/src/lib/components/landing/landing.component.scss
+++ b/libs/solid/skeleton/src/lib/components/landing/landing.component.scss
@@ -24,7 +24,6 @@ mat-list-item {
       padding: 0.7rem !important;
     }
     div.mat-line.md-rendered {
-      //margin-bottom: -1em;
       padding-left: 0.22rem !important;
       white-space: normal !important;
       h2 {

--- a/libs/solid/skeleton/src/lib/components/message-list/message-list.component.scss
+++ b/libs/solid/skeleton/src/lib/components/message-list/message-list.component.scss
@@ -14,8 +14,8 @@ mat-list-item {
       padding: 0 !important;
     }
     div.mat-line.md-rendered {
-      margin-bottom: -1em;
       padding-left: 0.22rem !important;
+      white-space: normal !important;
     }
   }
 }


### PR DESCRIPTION
Remove the white spaces between text in info. But i don't know how to deal with the markdown ### which you mean in the description. 