### PR TITLE
Prepare Planty Release 1.3.1

### DIFF
--- a/apps/planty/src/app/solid-skeleton-config.ts
+++ b/apps/planty/src/app/solid-skeleton-config.ts
@@ -12,7 +12,7 @@ export const skeletonConfig: SolidSkeletonConfig = {
     },
     profile: {
       svgIcon: 'profile',
-      url: 'steckbriefe',
+      url: 'profile',
     },
     quiz: {
       svgIcon: 'quiz',

--- a/libs/solid/core/src/lib/components/audio-icon/audio-icon.component.scss
+++ b/libs/solid/core/src/lib/components/audio-icon/audio-icon.component.scss
@@ -1,6 +1,4 @@
 svg {
-  margin-left: auto;
-  margin-right: auto;
+  margin: 0 auto;
   height: 100%;
-  margin-top: -1em;
 }

--- a/libs/solid/core/src/lib/components/audio-icon/audio-icon.component.ts
+++ b/libs/solid/core/src/lib/components/audio-icon/audio-icon.component.ts
@@ -13,8 +13,8 @@ export class AudioIconComponent implements OnChanges {
   }
 
   shortenTitle() {
-    if (this.title.length > 15) {
-      this.title = this.title.slice(0, 18) + '...';
+    if (this.title.length > 14) {
+      this.title = this.title.slice(0, 14) + '...';
     }
   }
 }

--- a/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.html
+++ b/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.html
@@ -1,10 +1,57 @@
-<button (click)="onPlayPauseClick()" mat-mini-fab color="accent">
-  <mat-icon>{{ Playing ? 'pause' : 'play_arrow' }}</mat-icon>
-</button>
+<ng-container *ngIf="!toolbar">
+  <button (click)="onPlayPauseClick()" mat-mini-fab color="accent">
+    <mat-icon>{{ playing ? 'pause' : 'play_arrow' }}</mat-icon>
+  </button>
+</ng-container>
+
+<ng-container *ngIf="toolbar">
+  <div class="toolbar" [class.mobile]="isMobile">
+    <button
+      mat-icon-button
+      [disabled]="!audioLoaded"
+      (click)="onPlayPauseClick()"
+    >
+      <mat-icon>{{ playing ? 'pause' : 'play_arrow' }}</mat-icon>
+    </button>
+    <button
+      mat-icon-button
+      [disabled]="!audioLoaded"
+      (click)="onReplayClick()"
+      class="replay-btn"
+    >
+      <mat-icon>replay</mat-icon>
+    </button>
+    {{ playPositionString }}
+    <mat-slider
+      min="0"
+      [max]="duration"
+      step="1"
+      [value]="playPosition"
+      [disabled]="!audioLoaded"
+      (input)="onPositionChangeEnd($event)"
+      class="playingSlider"
+    ></mat-slider>
+    <button mat-icon-button (click)="onVolumeMutingToggle()" class="volume-btn">
+      <mat-icon>{{ isMuted ? 'volume_off' : 'volume_up' }}</mat-icon>
+    </button>
+    <mat-slider
+      *ngIf="!isMobile"
+      min="0"
+      max="1"
+      step="0.1"
+      [value]="volume"
+      (input)="onVolumeChangeEnd($event)"
+      class="volumeSlider"
+    >
+    </mat-slider>
+  </div>
+</ng-container>
 <audio
   #audioplayer
   (timeupdate)="onPlayerTimeUpdate()"
   (ended)="onPlayerEnded()"
->
-  <source (error)="onPlayerMediaError()" [src]="audiosrc" type="audio/mpeg" />
-</audio>
+  (loadeddata)="onPlayerReady()"
+  [volume]="volume"
+  (error)="onPlayerMediaError()"
+  [src]="audiosrc"
+></audio>

--- a/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.html
+++ b/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.html
@@ -6,11 +6,7 @@
 
 <ng-container *ngIf="toolbar">
   <div class="toolbar" [class.mobile]="isMobile">
-    <button
-      mat-icon-button
-      [disabled]="!audioLoaded"
-      (click)="onPlayPauseClick()"
-    >
+    <button mat-icon-button (click)="onPlayPauseClick()">
       <mat-icon>{{ playing ? 'pause' : 'play_arrow' }}</mat-icon>
     </button>
     <button
@@ -31,21 +27,28 @@
       (input)="onPositionChangeEnd($event)"
       class="playingSlider"
     ></mat-slider>
-    <button mat-icon-button (click)="onVolumeMutingToggle()" class="volume-btn">
+    <button
+      mat-icon-button
+      [disabled]="!audioLoaded"
+      (click)="onVolumeMutingToggle()"
+      class="volume-btn"
+    >
       <mat-icon>{{ isMuted ? 'volume_off' : 'volume_up' }}</mat-icon>
     </button>
     <mat-slider
-      *ngIf="!isMobile"
       min="0"
       max="1"
       step="0.1"
       [value]="volume"
+      [disabled]="!audioLoaded"
       (input)="onVolumeChangeEnd($event)"
       class="volumeSlider"
+      [class.disappear]="isIOS() || isMobile"
     >
     </mat-slider>
   </div>
 </ng-container>
+
 <audio
   #audioplayer
   (timeupdate)="onPlayerTimeUpdate()"

--- a/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.scss
+++ b/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.scss
@@ -55,7 +55,8 @@ span.PlayPosition {
   .replay-btn {
     margin-right: 0.3em !important;
   }
-  .volume-btn {
-    margin-left: -0.3em !important;
-  }
+}
+
+.disappear {
+  display: none;
 }

--- a/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.scss
+++ b/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.scss
@@ -17,3 +17,45 @@ span.PlayPosition {
   vertical-align: middle;
   padding-left: 0.5em;
 }
+
+.toolbar {
+  width: 100%;
+  height: 48px;
+  box-shadow: 2px 2px 10px rgb(0 0 0 / 20%);
+  display: flex;
+  align-items: center;
+  padding: 0 17px 0 10px;
+
+  .replay-btn {
+    margin-right: 0.5em;
+  }
+
+  ::ng-deep {
+    .mat-slider-horizontal.playingSlider {
+      flex: 1;
+    }
+    .mat-slider-horizontal.volumeSlider {
+      min-width: 100px;
+      margin-left: -0.4em;
+    }
+    .mat-slider-thumb {
+      width: 10px;
+      height: 10px;
+      bottom: -5px;
+      background-color: rgba(0, 0, 0, 0.61);
+    }
+    .mat-slider-track-fill {
+      background-color: rgba(0, 0, 0, 0.61);
+    }
+  }
+}
+
+.mobile {
+  padding: 0 5px 0 3px !important;
+  .replay-btn {
+    margin-right: 0.3em !important;
+  }
+  .volume-btn {
+    margin-left: -0.3em !important;
+  }
+}

--- a/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.ts
+++ b/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.ts
@@ -1,4 +1,13 @@
-import { Component, Input, Inject, ViewChild, OnDestroy } from '@angular/core';
+import { BreakpointObserver } from '@angular/cdk/layout';
+import {
+  Component,
+  Input,
+  Inject,
+  ViewChild,
+  OnDestroy,
+  OnChanges,
+  OnInit,
+} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { SOLID_CORE_CONFIG, SolidCoreConfig } from '../../solid-core-config';
 import { MediaErrorDialogComponent } from '../media-error-dialog/media-error-dialog.component';
@@ -8,42 +17,63 @@ import { MediaErrorDialogComponent } from '../media-error-dialog/media-error-dia
   templateUrl: './audio-toolbar.component.html',
   styleUrls: ['./audio-toolbar.component.scss'],
 })
-export class AudioToolbarComponent implements OnDestroy {
+export class AudioToolbarComponent implements OnInit, OnDestroy, OnChanges {
   @Input() public audiosrc!: string;
   @Input() public description!: string;
+  @Input() public toolbar!: boolean;
   @ViewChild('audioplayer', { static: false }) player?: {
     nativeElement: HTMLAudioElement;
   };
-  public Playing = false;
-  public PlayingStarted = false;
-  public PlayPosition = '';
-  private loadError = false;
+  public audioLoaded = false;
+  public playing = false;
+  public playingStarted = false;
+  public playPositionString = '0:00/-:--';
+  public playPosition = 0;
+  public duration = 0;
+  public volume = 1;
+  public previousVolume = 0;
   public descriptionToggle = false;
+  public isMuted = false;
+  public isMobile = false;
 
   constructor(
     @Inject(SOLID_CORE_CONFIG) public coreConfig: SolidCoreConfig,
-    private _dialog: MatDialog
+    private _dialog: MatDialog,
+    private _breakpointObsever: BreakpointObserver
   ) {}
 
-  public onPlayPauseClick() {
-    if (this.loadError) {
-      this._dialog.open(MediaErrorDialogComponent, {
-        data: {
-          title: 'Fehler',
-          content: 'Audiodatei konnte nicht geladen werden.',
-        },
+  ngOnInit(): void {
+    this._breakpointObsever
+      .observe(['(max-width: 470px)'])
+      .subscribe((isMobile) => {
+        if (isMobile.matches) {
+          this.isMobile = true;
+        } else {
+          this.isMobile = false;
+        }
       });
-      return;
-    }
+  }
+
+  onPlayerReady(): void {
     if (this.player) {
-      if (this.Playing) {
+      this.audioLoaded = true;
+      this.duration = this.player.nativeElement.duration;
+      this.playPosition = 0;
+      this.displayPlayPosition(0);
+    }
+  }
+
+  public onPlayPauseClick() {
+    // where does this belong? This should be done somewhere else.
+    if (this.player) {
+      if (this.playing) {
         this.player.nativeElement.pause();
       } else {
-        this.PlayingStarted = true;
+        this.playingStarted = true;
         this.player.nativeElement.play();
       }
     }
-    this.Playing = !this.Playing;
+    this.playing = !this.playing;
   }
 
   public onReplayClick() {
@@ -51,38 +81,75 @@ export class AudioToolbarComponent implements OnDestroy {
       this.player.nativeElement.pause();
       this.player.nativeElement.currentTime = 0;
       this.player.nativeElement.play();
-      this.Playing = true;
+      this.playing = true;
     }
   }
 
   public onPlayerTimeUpdate() {
     if (this.player) {
-      const duration = this.player.nativeElement.duration;
-      const currentTime = this.player.nativeElement.currentTime;
-      const durationSeconds = Math.floor(duration % 60);
+      this.displayPlayPosition(this.player.nativeElement.currentTime);
+    }
+  }
+
+  public displayPlayPosition(currentTime: number) {
+    if (this.player) {
+      const durationSeconds = Math.floor(this.duration % 60);
       const currentTimeSeconds = Math.floor(currentTime % 60);
-      if (currentTime > 0) {
-        this.PlayPosition = `${Math.floor(currentTime / 60)}:${
-          currentTimeSeconds < 10
-            ? '0' + currentTimeSeconds
-            : currentTimeSeconds
-        }/${Math.floor(duration / 60)}:${
-          durationSeconds < 10 ? '0' + durationSeconds : durationSeconds
-        }`;
-        return;
+      this.playPositionString = `${Math.floor(currentTime / 60)}:${
+        currentTimeSeconds < 10 ? '0' + currentTimeSeconds : currentTimeSeconds
+      }/${Math.floor(this.duration / 60)}:${
+        durationSeconds < 10 ? '0' + durationSeconds : durationSeconds
+      }`;
+      this.playPosition = currentTime;
+      return;
+    }
+    this.playPosition = 0;
+  }
+
+  // shouldn't we work with EventEmitter<> somehow? It works, though.
+  onPositionChangeEnd(change: any) {
+    if (this.player) {
+      this.player.nativeElement.currentTime = change.value;
+    }
+  }
+  // same here
+  public onVolumeChangeEnd(change: any) {
+    if (this.player) {
+      this.isMuted = false;
+      this.player.nativeElement.volume = change.value;
+      this.volume = change.value;
+    }
+  }
+
+  public onVolumeMutingToggle() {
+    if (this.player) {
+      this.isMuted = !this.isMuted;
+      if (this.isMuted) {
+        this.player.nativeElement.volume = 0;
+        this.previousVolume = this.volume;
+        this.volume = 0;
+      } else {
+        this.player.nativeElement.volume = this.previousVolume;
+        this.volume = this.previousVolume;
       }
     }
-    this.PlayPosition = '';
   }
 
   public onPlayerMediaError() {
-    this.loadError = true;
+    this.audioLoaded = false;
+    this._dialog.open(MediaErrorDialogComponent, {
+      data: {
+        title: 'Fehler',
+        content: 'Audiodatei konnte nicht geladen werden.',
+      },
+    });
+    return;
   }
 
   public onPlayerEnded() {
     if (this.player) {
-      this.PlayingStarted = false;
-      this.Playing = false;
+      this.playingStarted = false;
+      this.playing = false;
       this.player.nativeElement.currentTime = 0;
     }
   }
@@ -91,8 +158,14 @@ export class AudioToolbarComponent implements OnDestroy {
     this.descriptionToggle = !this.descriptionToggle;
   }
 
+  ngOnChanges(): void {
+    if (this.playingStarted && this.player) {
+      this.playing = false;
+    }
+  }
+
   ngOnDestroy(): void {
-    if (this.PlayingStarted && this.player) {
+    if (this.playingStarted && this.player) {
       this.player.nativeElement.pause();
     }
   }

--- a/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.ts
+++ b/libs/solid/core/src/lib/components/audio-toolbar/audio-toolbar.component.ts
@@ -32,7 +32,6 @@ export class AudioToolbarComponent implements OnInit, OnDestroy, OnChanges {
   public duration = 0;
   public volume = 1;
   public previousVolume = 0;
-  public descriptionToggle = false;
   public isMuted = false;
   public isMobile = false;
 
@@ -54,6 +53,24 @@ export class AudioToolbarComponent implements OnInit, OnDestroy, OnChanges {
       });
   }
 
+  isIOS(): boolean {
+    return (
+      [
+        'iPad Simulator',
+        'iPhone Simulator',
+        'iPod Simulator',
+        'iPad',
+        'iPhone',
+        'iPod',
+        // tslint:disable-next-line: deprecation
+      ].includes(navigator.platform) ||
+      navigator.userAgent.includes('iPad') ||
+      navigator.userAgent.includes('iPhone') ||
+      // iPad on iOS 13 detection
+      (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
+    );
+  }
+
   onPlayerReady(): void {
     if (this.player) {
       this.audioLoaded = true;
@@ -64,7 +81,6 @@ export class AudioToolbarComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   public onPlayPauseClick() {
-    // where does this belong? This should be done somewhere else.
     if (this.player) {
       if (this.playing) {
         this.player.nativeElement.pause();
@@ -106,13 +122,12 @@ export class AudioToolbarComponent implements OnInit, OnDestroy, OnChanges {
     this.playPosition = 0;
   }
 
-  // shouldn't we work with EventEmitter<> somehow? It works, though.
-  onPositionChangeEnd(change: any) {
+  public onPositionChangeEnd(change: any) {
     if (this.player) {
       this.player.nativeElement.currentTime = change.value;
     }
   }
-  // same here
+
   public onVolumeChangeEnd(change: any) {
     if (this.player) {
       this.isMuted = false;
@@ -125,11 +140,11 @@ export class AudioToolbarComponent implements OnInit, OnDestroy, OnChanges {
     if (this.player) {
       this.isMuted = !this.isMuted;
       if (this.isMuted) {
-        this.player.nativeElement.volume = 0;
+        this.player.nativeElement.muted = true;
         this.previousVolume = this.volume;
         this.volume = 0;
       } else {
-        this.player.nativeElement.volume = this.previousVolume;
+        this.player.nativeElement.muted = false;
         this.volume = this.previousVolume;
       }
     }
@@ -154,13 +169,12 @@ export class AudioToolbarComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  public toggleDescription() {
-    this.descriptionToggle = !this.descriptionToggle;
-  }
-
   ngOnChanges(): void {
     if (this.playingStarted && this.player) {
       this.playing = false;
+      this.audioLoaded = false;
+      this.playPositionString = '0:00/-:--';
+      this.playPosition = 0;
     }
   }
 

--- a/libs/solid/core/src/lib/components/media-detail/media-detail.component.html
+++ b/libs/solid/core/src/lib/components/media-detail/media-detail.component.html
@@ -51,8 +51,11 @@ use the ImageModel, but now the image toolbar uses the MediaObjectModel -->
           [title]="mediaObject.getTitle"
         ></solid-core-audio-icon>
         <div *ngIf="descriptionShow" id="description-container">
-          <div id="description">
+          <div *ngIf="mediaObject.description" id="description">
             <p markdown [data]="mediaObject.description!"></p>
+          </div>
+          <div *ngIf="!mediaObject.description" id="description">
+            <p>Leider haben wir keine Beschreibung</p>
           </div>
         </div>
       </div>

--- a/libs/solid/core/src/lib/components/media-detail/media-detail.component.html
+++ b/libs/solid/core/src/lib/components/media-detail/media-detail.component.html
@@ -23,7 +23,7 @@ use the ImageModel, but now the image toolbar uses the MediaObjectModel -->
 <!-- For media object in Profile -->
 <ng-container *ngIf="mediaObject">
   <ng-container [ngSwitch]="mediaObject.mediaType">
-    <div class="container" *ngSwitchCase="'image'">
+    <div class="media-container" *ngSwitchCase="'image'">
       <img
         *ngIf="view != 'grid'; else grid"
         [src]="mediaObject.getRawImage('large')"
@@ -31,14 +31,19 @@ use the ImageModel, but now the image toolbar uses the MediaObjectModel -->
         [class.landscape]="mediaObject.isLandscape"
       />
     </div>
-    <div class="container" *ngSwitchCase="'audio'">
-      <div id="audio-container">
-        <audio
-          *ngIf="hasControlPanel"
-          id="audio"
-          [src]="mediaObject.getSrc()"
-          controls
-        ></audio>
+    <div class="media-container" *ngSwitchCase="'audio'">
+      <!-- <img
+        *ngIf="view != 'grid'; else grid"
+        [src]="'assets/profile/planty_audio.svg'"
+        [alt]="mediaObject.alt"
+        [class.landscape]="mediaObject.isLandscape"
+      /> -->
+      <div class="audio-container">
+        <solid-core-audio-toolbar
+          *ngIf="view != 'grid'"
+          [audiosrc]="mediaObject.getSrc()!"
+          [toolbar]="true"
+        ></solid-core-audio-toolbar>
       </div>
       <div id="svg-description-container">
         <solid-core-audio-icon
@@ -52,7 +57,7 @@ use the ImageModel, but now the image toolbar uses the MediaObjectModel -->
         </div>
       </div>
     </div>
-    <div class="container" *ngSwitchCase="'video'">
+    <div class="media-container" *ngSwitchCase="'video'">
       <video
         #videoplayer
         id="video"
@@ -99,7 +104,7 @@ use the ImageModel, but now the image toolbar uses the MediaObjectModel -->
     />
     <img
       *ngIf="mediaObject.mediaType === 'audio'"
-      [src]="'assets/profile/planty_audio.svg'"
+      [src]="'assets/profile/audio.svg'"
       [alt]="mediaObject.alt"
     />
   </ng-template>

--- a/libs/solid/core/src/lib/components/media-detail/media-detail.component.html
+++ b/libs/solid/core/src/lib/components/media-detail/media-detail.component.html
@@ -8,6 +8,16 @@ use the ImageModel, but now the image toolbar uses the MediaObjectModel -->
     [alt]="image.alt"
     [class.landscape]="image.isLandscape"
   />
+  <solid-core-media-toolbar
+    *ngIf="view != 'grid'"
+    [image]="image"
+    [name]="name"
+    [hasAttributions]="hasAttributions"
+    [hasDialog]="hasDialog"
+    [hasDziTools]="false"
+    [hasAudio]="hasAudio"
+    [hasDescription]="hasDescription"
+  ></solid-core-media-toolbar>
 </ng-container>
 
 <!-- For media object in Profile -->

--- a/libs/solid/core/src/lib/components/media-detail/media-detail.component.scss
+++ b/libs/solid/core/src/lib/components/media-detail/media-detail.component.scss
@@ -20,83 +20,73 @@ img {
     border-radius: inherit;
   }
 }
-.container {
+.media-container {
   display: block;
   height: 100%;
   border-radius: inherit;
   position: relative;
   margin-bottom: -48px;
   box-sizing: border-box;
-}
-#video {
-  max-height: 100%;
-  max-width: 100%;
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-  height: auto;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translateY(-50%) translateX(-50%);
-}
-.play-button-wrapper {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: auto;
-  pointer-events: none;
-  #play-button-circle {
-    cursor: pointer;
-    pointer-events: auto;
 
-    svg {
-      width: 60px;
-      height: 60px;
-      fill: #fff;
-      stroke: #fff;
-      cursor: pointer;
-      background-color: rgba(black, 0.2);
-      border-radius: 50%;
-      opacity: 0.9;
+  .audio-container {
+    text-align: center;
+  }
+
+  #svg-description-container {
+    text-align: center;
+    margin-top: 0em;
+    height: 75%;
+
+    #description-container {
+      padding: 2em 0em 2em 2em;
+      text-align: justify;
+      height: 100%;
+      #description {
+        height: 100%;
+        overflow: auto;
+        padding-right: 2em;
+      }
     }
   }
-}
 
-#audio-container {
-  text-align: center;
-  padding-top: 1.5em;
-}
+  #video {
+    max-height: 100%;
+    max-width: 100%;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    height: auto;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateY(-50%) translateX(-50%);
+  }
+  .play-button-wrapper {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: auto;
+    pointer-events: none;
+    #play-button-circle {
+      cursor: pointer;
+      pointer-events: auto;
 
-#audio {
-  max-width: 90%;
-  min-width: 40%;
-  box-shadow: 5px 5px 20px rgba(0, 0, 0, 0.4);
-  border-radius: 90px;
-  transform: scale(1.05);
-  z-index: 999;
-  height: 40px;
-}
-
-#svg-description-container {
-  text-align: center;
-  margin-top: 0em;
-  height: 75%;
-
-  #description-container {
-    padding: 2em 0em 2em 2em;
-    text-align: justify;
-    height: 100%;
-    #description {
-      height: 100%;
-      overflow: auto;
-      padding-right: 2em;
+      svg {
+        width: 60px;
+        height: 60px;
+        fill: #fff;
+        stroke: #fff;
+        cursor: pointer;
+        background-color: rgba(black, 0.2);
+        border-radius: 50%;
+        opacity: 0.9;
+      }
     }
   }
 }

--- a/libs/solid/core/src/lib/components/media-dialog/media-dialog.component.html
+++ b/libs/solid/core/src/lib/components/media-dialog/media-dialog.component.html
@@ -35,6 +35,7 @@
   <div mat-dialog-content>
     <solid-core-media-detail
       [mediaObject]="data.mediaObject"
+      [image]="data.mediaObject"
       [hasDialog]="false"
       [hasControlPanel]="true"
       [hasDescription]="hasDescription"

--- a/libs/solid/core/src/lib/components/media-dialog/media-dialog.component.html
+++ b/libs/solid/core/src/lib/components/media-dialog/media-dialog.component.html
@@ -43,6 +43,7 @@
     <div class="audiobar">
       <solid-core-audio-toolbar
         class="audiobar"
+        [toolbar]="false"
         *ngIf="hasAudio"
         [audiosrc]="data.mediaObject.audiosrc"
       >

--- a/libs/solid/core/src/lib/components/media-dialog/media-dialog.component.ts
+++ b/libs/solid/core/src/lib/components/media-dialog/media-dialog.component.ts
@@ -37,11 +37,11 @@ export class MediaDialogComponent implements AfterViewInit, OnDestroy, OnInit {
           this.isAttributionsOverlayAbove = true;
         }
       });
-    console.log(this.data);
   }
 
   ngAfterViewInit(): void {
     let dzi = this.data.mediaObject.deepZoomLink;
+
     if (dzi) {
       if (!this.coreConfig.production) {
         // TODO: This workaround is required for deepzoom in dev environments. It will not work with other cdn domains.

--- a/libs/solid/core/src/lib/components/media-toolbar/media-toolbar.component.html
+++ b/libs/solid/core/src/lib/components/media-toolbar/media-toolbar.component.html
@@ -7,7 +7,7 @@
     >
     </solid-core-audio-toolbar>
   </ng-container>
-  <div class="dziToolbar">
+  <div class="dziToolbar" *ngIf="mediaObject">
     <button
       *ngIf="hasAttributions && mediaObject.attributions as attributions"
       mat-mini-fab
@@ -77,6 +77,48 @@
       mat-mini-fab
       color="accent"
       (click)="openDialog()"
+    >
+      <mat-icon>more_horiz</mat-icon>
+    </button>
+  </div>
+
+  <!-- For Image in quiz -->
+  <div class="dziToolbar" *ngIf="image">
+    <button
+      *ngIf="hasAttributions && image.attributions as attributions"
+      mat-mini-fab
+      color="accent"
+      cdkOverlayOrigin
+      #attributionsOverlayOrigin="cdkOverlayOrigin"
+      (click)="attributionsOpenClose()"
+    >
+      <mat-icon>copyright</mat-icon>
+      <ng-template
+        cdkConnectedOverlay
+        [cdkConnectedOverlayOrigin]="attributionsOverlayOrigin"
+        [cdkConnectedOverlayOpen]="attributionsIsOpen"
+        [cdkConnectedOverlayPositions]="attributionsPositions"
+        [cdkConnectedOverlayScrollStrategy]="attributionsScrollStrategy"
+      >
+        <div class="attributions-overlay">{{ attributions }}</div>
+      </ng-template>
+    </button>
+    <ng-container *ngIf="hasDziTools">
+      <button id="zoom-in-button" mat-mini-fab color="accent">
+        <mat-icon>zoom_in</mat-icon>
+      </button>
+      <button id="zoom-out-button" mat-mini-fab color="accent">
+        <mat-icon>zoom_out</mat-icon>
+      </button>
+      <button id="home-button" mat-mini-fab color="accent">
+        <mat-icon>home</mat-icon>
+      </button>
+    </ng-container>
+    <button
+      *ngIf="hasDialog"
+      mat-mini-fab
+      color="accent"
+      (click)="openDialogImage()"
     >
       <mat-icon>more_horiz</mat-icon>
     </button>

--- a/libs/solid/core/src/lib/components/media-toolbar/media-toolbar.component.ts
+++ b/libs/solid/core/src/lib/components/media-toolbar/media-toolbar.component.ts
@@ -7,7 +7,7 @@ import {
   OnInit,
   Output,
 } from '@angular/core';
-import { MediaModel } from '../../models';
+import { ImageModel, MediaModel } from '../../models';
 import { MatDialog } from '@angular/material/dialog';
 import {
   CloseScrollStrategy,
@@ -25,6 +25,7 @@ import { BreakpointObserver } from '@angular/cdk/layout';
 })
 export class MediaToolbarComponent implements OnInit, OnChanges {
   @Input() public mediaObject!: MediaModel;
+  @Input() public image!: ImageModel;
   @Input() public name!: string;
   @Input() hasAttributions!: boolean;
   @Input() hasDialog!: boolean;
@@ -114,6 +115,20 @@ export class MediaToolbarComponent implements OnInit, OnChanges {
       panelClass: 'solid-core-media-dialog',
       data: {
         mediaObject: this.mediaObject,
+        name: this.name,
+      },
+    });
+  }
+
+  public openDialogImage() {
+    this._dialog.open(MediaDialogComponent, {
+      maxWidth: this.length + 'vw',
+      width: '100%',
+      height: '100%',
+      maxHeight: this.length + 'vh',
+      panelClass: 'solid-core-media-dialog',
+      data: {
+        mediaObject: this.image,
         name: this.name,
       },
     });

--- a/libs/solid/core/src/lib/solid-core.module.ts
+++ b/libs/solid/core/src/lib/solid-core.module.ts
@@ -13,6 +13,7 @@ import { MarkdownComponent, MediaComponent } from './components';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatSliderModule } from '@angular/material/slider';
 import { MediaDialogComponent } from './components/media-dialog/media-dialog.component';
 import { MediaDetailComponent } from './components/media-detail/media-detail.component';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -41,6 +42,7 @@ import { AudioIconComponent } from './components/audio-icon/audio-icon.component
     MatButtonModule,
     MatDialogModule,
     ScrollingModule,
+    MatSliderModule,
   ],
   exports: [
     CommonModule,

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "codelyzer": "6.0.2",
     "cypress": "^6.9.1",
     "fs-extra": "^9.0.0",
-    "git-describe": "^4.0.4",
+    "git-describe": "^4.1.0",
     "jasmine": "^3.9.0",
     "jasmine-core": "3.6.0",
     "jasmine-spec-reporter": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@types/node": "16.7.10",
     "@types/openseadragon": "^2.4.7",
     "@types/punycode": "^2.1.0",
-    "@types/swagger-schema-official": "^2.0.21",
+    "@types/swagger-schema-official": "^2.0.22",
     "canvas": "^2.6.1",
     "codelyzer": "6.0.2",
     "cypress": "^6.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,10 +2502,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/swagger-schema-official@^2.0.21":
-  version "2.0.21"
-  resolved "https://registry.yarnpkg.com/@types/swagger-schema-official/-/swagger-schema-official-2.0.21.tgz#56812a86dcd57ba60e5c51705ee96a2b2dc9b374"
-  integrity sha512-n9BbLOjR4Hre7B4TSGGMPohOgOg8tcp00uxqsIE00uuWQC0QuX57G1bqC1csLsk2DpTGtHkd0dEb3ipsCZ9dAA==
+"@types/swagger-schema-official@^2.0.22":
+  version "2.0.22"
+  resolved "https://registry.yarnpkg.com/@types/swagger-schema-official/-/swagger-schema-official-2.0.22.tgz#f7e06168e6994574dfd86928ac04b196870ab043"
+  integrity sha512-7yQiX6MWSFSvc/1wW5smJMZTZ4fHOd+hqLr3qr/HONDxHEa2bnYAsOcGBOEqFIjd4yetwMOdEDdeW+udRAQnHA==
 
 "@types/webpack-sources@^0.1.5":
   version "0.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2482,6 +2482,11 @@
   resolved "https://registry.yarnpkg.com/@types/selenium-webdriver/-/selenium-webdriver-3.0.17.tgz#50bea0c3c2acc31c959c5b1e747798b3b3d06d4b"
   integrity sha512-tGomyEuzSC1H28y2zlW6XPCaDaXFaD6soTdb4GNdmte2qfHtrKqhy0ZFs4r/1hpazCfEZqeTSRLvSasmEx89uw==
 
+"@types/semver@^7.3.8":
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
+  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
+
 "@types/sinonjs__fake-timers@^6.0.1":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz#3a84cf5ec3249439015e14049bd3161419bf9eae"
@@ -6209,12 +6214,13 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-git-describe@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/git-describe/-/git-describe-4.0.4.tgz#f3d55bce309becf6dc27fed535d380a621967e8c"
-  integrity sha512-L1X9OO1e4MusB4PzG9LXeXCQifRvyuoHTpuuZ521Qyxn/B0kWHWEOtsT4LsSfSNacZz0h4ZdYDsDG7f+SrA3hg==
+git-describe@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/git-describe/-/git-describe-4.1.0.tgz#0c50fa1ec5ead55932b6e875b2299b17ce5e07d3"
+  integrity sha512-NM7JSseVK4Z0r505+2TIrgPQKPvqbOowHP73IY5y69v/t/PmoMleJdij1vTO3qVm1qSvqb6342p1MYSxsnV8QA==
   dependencies:
-    lodash "^4.17.11"
+    "@types/semver" "^7.3.8"
+    lodash "^4.17.21"
   optionalDependencies:
     semver "^5.6.0"
 


### PR DESCRIPTION
* fix a few issues that arose after the 1.3.0 release
  * custom routing to `/steckbriefe/` invalidated the QR-code paths
  * adapted truncation threshold in audio svg
  * do not show audio description button if description is empty
* implement custom audio player toolbar (and address some OS specific issues)      