### PR TITLE
re-enable dive auto-deploy on build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,3 +81,14 @@ jobs:
           source: 'dist/apps/ais'
           target: '${{ secrets.AIS_STAGING_DIRECTORY }}'
           strip_components: 3
+
+      - name: Deploy dive-staging
+        uses: appleboy/scp-action@v0.0.10
+        with:
+          host: ${{ secrets.SERVER }}
+          username: ${{ secrets.USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          rm: true
+          source: 'dist/apps/dive'
+          target: '${{ secrets.DIVE_STAGING_DIRECTORY }}'
+          strip_components: 3

--- a/apps/planty/src/app/landing-banner-content/landing-banner-content.component.html
+++ b/apps/planty/src/app/landing-banner-content/landing-banner-content.component.html
@@ -1,7 +1,7 @@
 <mat-card-header>
   <img mat-card-avatar src="assets/icons/icon.svg" />
   <mat-card-title>Pflanzenlernportal der Hochschule Geisenheim</mat-card-title>
-  <mat-card-subtitle>Herzlich willkommen bei Planty2Learn!</mat-card-subtitle>
+  <mat-card-subtitle>Herzlich willkommen bei PLANTY2Learn!</mat-card-subtitle>
   <div class="spacer"></div>
   <button (click)="onCloseClick()" mat-icon-button>
     <mat-icon>close</mat-icon>

--- a/apps/planty/src/app/privacy/privacy.component.html
+++ b/apps/planty/src/app/privacy/privacy.component.html
@@ -118,7 +118,7 @@ Art der Speicherung keinen unverhältnismäßig hohen Aufwand verursacht.<br />
 
 <h4>Lokaler Speicher</h4>
 <p>
-  Planty2Learn nutzt den lokalen Browserspeicher (Local Storage und Session
+  PLANTY2Learn nutzt den lokalen Browserspeicher (Local Storage und Session
   Storage), um einige Anzeigeeinstellungen zu speichern. Diese bleiben ggf. auch
   nach Verlassen der Seite erhalten. Hierbei werden keine personenbezogenen
   Daten gespeichert.

--- a/apps/planty/src/index.html
+++ b/apps/planty/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Planty2Learn</title>
+    <title>PLANTY2Learn</title>
     <base href="/" />
     <meta
       name="viewport"


### PR DESCRIPTION
Add github action to auto-deploy Div-e Staging

(Div-e has been exluded from standard deploy due to the missing implementation of the MediaObject.)