### PR TITLE
remove double version handling

### DIFF
--- a/apps/ais/src/app/info-page-content/info-page-content.component.html
+++ b/apps/ais/src/app/info-page-content/info-page-content.component.html
@@ -1,6 +1,5 @@
 <h2>Über die App</h2>
-<p>s.o.l.i.d. Version: {{ solidVersion }}</p>
-<p *ngIf="appVersion !== undefined">AIS Version: {{ appVersion }}</p>
+<p>App Version: {{ appVersion }}</p>
 
 <div class="solid-logo">
   <img alt="Solid Logo" src="assets/info/Solid.svg" />

--- a/apps/ais/src/app/info-page-content/info-page-content.component.ts
+++ b/apps/ais/src/app/info-page-content/info-page-content.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { version } from '../../environments/version';
-import pjs from '../../../../../package.json';
 
 import {
   FeedbackService,
@@ -16,8 +15,7 @@ export class InfoPageContentComponent {
   public appVersion =
     version && version.semver && version.semver.version
       ? version.semver.version
-      : undefined;
-  public solidVersion = pjs.version ? pjs.version : 'Version unbekannt';
+      : 'Version unbekannt';
 
   constructor(
     @Inject(SOLID_SKELETON_FEEDBACK_SERVICE) public feedback: FeedbackService

--- a/apps/ais/src/app/privacy/privacy.component.html
+++ b/apps/ais/src/app/privacy/privacy.component.html
@@ -113,7 +113,8 @@ Art der Speicherung keinen unverhältnismäßig hohen Aufwand verursacht.<br />
   Smartphone o.ä.) spezifische, auf das Gerät bezogene Informationen zu
   speichern. Sie dienen zum einem der Benutzerfreundlichkeit von Webseiten (z.B.
   Speicherung von Logindaten). Zum jetzigen Zeitpunkt speichert AIS keine
-  Cookies auf Ihrem Gerät.
+  Cookies auf Ihrem Gerät. Cookies werden jedoch im Falle eines Fehlers vom
+  Fehlerüberwachungsdienst Sentry gespeichert (siehe unten).
 </p>
 
 <h4>Lokaler Speicher</h4>
@@ -128,12 +129,19 @@ Art der Speicherung keinen unverhältnismäßig hohen Aufwand verursacht.<br />
 <p>
   Wir verwenden den Dienst Sentry, um die technische Stabilität unserer App
   durch Überwachung der Systemstabilität und Ermittlung von Codefehlern zu
-  verbessern. Sentry dient alleine diesen Zielen und wertet keine Daten zu
-  Werbezwecken aus. Die Daten der Nutzer, wie z.B. Angaben zum Gerät oder
-  Fehlerzeitpunkt werden anonym erhoben und nicht personenbezogen genutzt sowie
-  anschließend gelöscht. Bei Abstürzen ermöglicht Sentry die Eingabe einer
-  Fehlerbeschreibung. Die im Absturzbericht eingegebene E-Mail-Adresse wird zur
-  weiteren Bearbeitung des Anliegens bei den Entwicklern gespeichert.Sentry wird
-  lokal auf Rechnern der Goethe-Universität gehostet; es werden keine Daten nach
-  außen übertragen.
+  verbessern.
+</p>
+<p>
+  Sentry dient alleine diesen Zielen und wertet keine Daten zu Werbezwecken aus.
+  Die Daten der Nutzer, wie z.B. Angaben zum Gerät oder Fehlerzeitpunkt werden
+  anonym erhoben und nicht personenbezogen genutzt sowie anschließend gelöscht.
+  Bei Abstürzen setzt Sentry ein <i>Session-Cookie</i> mit Fehlerinformationen.
+  Zusätzlich erscheint ein Fenster mit der Möglichkeit, eine Fehlerbeschreibung
+  anzugeben. Im Absturzbericht kann eine Mail-Adresse angegeben werden, die zur
+  weiteren Bearbeitung des Anliegens bei den Entwicklern gespeichert wird. Die
+  Angabe einer Mail-Adresse ist freiwillig.
+</p>
+<p>
+  Sentry wird lokal auf Rechnern der Goethe-Universität gehostet; es werden
+  keine Daten nach außen übertragen.
 </p>

--- a/apps/dive/src/app/info-page-content/info-page-content.component.html
+++ b/apps/dive/src/app/info-page-content/info-page-content.component.html
@@ -1,6 +1,5 @@
 <h2>Über die App</h2>
-<p>s.o.l.i.d. Version: {{ solidVersion }}</p>
-<p *ngIf="appVersion !== undefined">Div-e Version: {{ appVersion }}</p>
+<p>App Version: {{ appVersion }}</p>
 
 <div class="solid-logo">
   <img alt="Solid Logo" src="assets/info/Solid.svg" />
@@ -30,8 +29,8 @@
   E-Learning-Anwendungen bildet.
 </p>
 <p>
-  ist eine Plattform für die strukturierte Darstellung von Objekten. Sie bringt
-  Bild-, Video- und Audiomaterial sowie objekttypische Merkmale in
+  s.o.l.i.d. ist eine Plattform für die strukturierte Darstellung von Objekten.
+  Sie bringt Bild-, Video- und Audiomaterial sowie objekttypische Merkmale in
   übersichtlicher Form zusammen.
 </p>
 <h2>Ziele der App</h2>

--- a/apps/dive/src/app/info-page-content/info-page-content.component.ts
+++ b/apps/dive/src/app/info-page-content/info-page-content.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject } from '@angular/core';
 import { version } from '../../environments/version';
-import pjs from '../../../../../package.json';
 
 import {
   FeedbackService,
@@ -16,8 +15,7 @@ export class InfoPageContentComponent {
   public appVersion =
     version && version.semver && version.semver.version
       ? version.semver.version
-      : undefined;
-  public solidVersion = pjs.version ? pjs.version : 'Version unbekannt';
+      : 'Version unbekannt';
 
   constructor(
     @Inject(SOLID_SKELETON_FEEDBACK_SERVICE) public feedback: FeedbackService

--- a/apps/dive/src/app/privacy/privacy.component.html
+++ b/apps/dive/src/app/privacy/privacy.component.html
@@ -113,7 +113,8 @@ Art der Speicherung keinen unverhältnismäßig hohen Aufwand verursacht.<br />
   Smartphone o.ä.) spezifische, auf das Gerät bezogene Informationen zu
   speichern. Sie dienen zum einem der Benutzerfreundlichkeit von Webseiten (z.B.
   Speicherung von Logindaten). Zum jetzigen Zeitpunkt speichert Div-e keine
-  Cookies auf Ihrem Gerät.
+  Cookies auf Ihrem Gerät. Cookies werden jedoch im Falle eines technischen
+  Fehlers vom Fehlerüberwachungsdienst Sentry gespeichert (siehe unten).
 </p>
 
 <h4>Lokaler Speicher</h4>
@@ -128,12 +129,19 @@ Art der Speicherung keinen unverhältnismäßig hohen Aufwand verursacht.<br />
 <p>
   Wir verwenden den Dienst Sentry, um die technische Stabilität unserer App
   durch Überwachung der Systemstabilität und Ermittlung von Codefehlern zu
-  verbessern. Sentry dient alleine diesen Zielen und wertet keine Daten zu
-  Werbezwecken aus. Die Daten der Nutzer, wie z.B. Angaben zum Gerät oder
-  Fehlerzeitpunkt werden anonym erhoben und nicht personenbezogen genutzt sowie
-  anschließend gelöscht. Bei Abstürzen ermöglicht Sentry die Eingabe einer
-  Fehlerbeschreibung. Die im Absturzbericht eingegebene E-Mail-Adresse wird zur
-  weiteren Bearbeitung des Anliegens bei den Entwicklern gespeichert.Sentry wird
-  lokal auf Rechnern der Goethe-Universität gehostet; es werden keine Daten nach
-  außen übertragen.
+  verbessern.
+</p>
+<p>
+  Sentry dient alleine diesen Zielen und wertet keine Daten zu Werbezwecken aus.
+  Die Daten der Nutzer, wie z.B. Angaben zum Gerät oder Fehlerzeitpunkt werden
+  anonym erhoben und nicht personenbezogen genutzt sowie anschließend gelöscht.
+  Bei Abstürzen setzt Sentry ein <i>Session-Cookie</i> mit Fehlerinformationen.
+  Zusätzlich erscheint ein Fenster mit der Möglichkeit, eine Fehlerbeschreibung
+  anzugeben. Im Absturzbericht kann eine Mail-Adresse angegeben werden, die zur
+  weiteren Bearbeitung des Anliegens bei den Entwicklern gespeichert wird. Die
+  Angabe einer Mail-Adresse ist freiwillig.
+</p>
+<p>
+  Sentry wird lokal auf Rechnern der Goethe-Universität gehostet; es werden
+  keine Daten nach außen übertragen.
 </p>

--- a/apps/geomat/src/app/info-page-content/info-page-content.component.html
+++ b/apps/geomat/src/app/info-page-content/info-page-content.component.html
@@ -1,6 +1,6 @@
 <h2>Über die App</h2>
-<p>s.o.l.i.d. Version: {{ solidVersion }}</p>
-<p *ngIf="appVersion !== undefined">GeoMat Version: {{ appVersion }}</p>
+<p>App Version: {{ appVersion }}</p>
+
 <div class="solid-logo">
   <img alt="Solid Logo" src="assets/info/Solid.svg" />
 </div>

--- a/apps/geomat/src/app/info-page-content/info-page-content.component.ts
+++ b/apps/geomat/src/app/info-page-content/info-page-content.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject } from '@angular/core';
 import { version } from '../../environments/version';
-import pjs from '../../../../../package.json';
 
 import {
   FeedbackService,
@@ -16,8 +15,7 @@ export class InfoPageContentComponent {
   public appVersion =
     version && version.semver && version.semver.version
       ? version.semver.version
-      : undefined;
-  public solidVersion = pjs.version ? pjs.version : 'Version unbekannt';
+      : 'Version unbekannt';
 
   constructor(
     @Inject(SOLID_SKELETON_FEEDBACK_SERVICE) public feedback: FeedbackService

--- a/apps/geomat/src/app/privacy/privacy.component.html
+++ b/apps/geomat/src/app/privacy/privacy.component.html
@@ -113,7 +113,8 @@ Art der Speicherung keinen unverhältnismäßig hohen Aufwand verursacht.<br />
   Smartphone o.ä.) spezifische, auf das Gerät bezogene Informationen zu
   speichern. Sie dienen zum einem der Benutzerfreundlichkeit von Webseiten (z.B.
   Speicherung von Logindaten). Zum jetzigen Zeitpunkt speichert GeoMat keine
-  Cookies auf Ihrem Gerät.
+  Cookies auf Ihrem Gerät. Cookies werden jedoch im Falle eines technischen
+  Fehlers vom Fehlerüberwachungsdienst Sentry gespeichert (siehe unten).
 </p>
 
 <h4>Lokaler Speicher</h4>
@@ -128,12 +129,19 @@ Art der Speicherung keinen unverhältnismäßig hohen Aufwand verursacht.<br />
 <p>
   Wir verwenden den Dienst Sentry, um die technische Stabilität unserer App
   durch Überwachung der Systemstabilität und Ermittlung von Codefehlern zu
-  verbessern. Sentry dient alleine diesen Zielen und wertet keine Daten zu
-  Werbezwecken aus. Die Daten der Nutzer, wie z.B. Angaben zum Gerät oder
-  Fehlerzeitpunkt werden anonym erhoben und nicht personenbezogen genutzt sowie
-  anschließend gelöscht. Bei Abstürzen ermöglicht Sentry die Eingabe einer
-  Fehlerbeschreibung. Die im Absturzbericht eingegebene E-Mail-Adresse wird zur
-  weiteren Bearbeitung des Anliegens bei den Entwicklern gespeichert.Sentry wird
-  lokal auf Rechnern der Goethe-Universität gehostet; es werden keine Daten nach
-  außen übertragen.
+  verbessern.
+</p>
+<p>
+  Sentry dient alleine diesen Zielen und wertet keine Daten zu Werbezwecken aus.
+  Die Daten der Nutzer, wie z.B. Angaben zum Gerät oder Fehlerzeitpunkt werden
+  anonym erhoben und nicht personenbezogen genutzt sowie anschließend gelöscht.
+  Bei Abstürzen setzt Sentry ein <i>Session-Cookie</i> mit Fehlerinformationen.
+  Zusätzlich erscheint ein Fenster mit der Möglichkeit, eine Fehlerbeschreibung
+  anzugeben. Im Absturzbericht kann eine Mail-Adresse angegeben werden, die zur
+  weiteren Bearbeitung des Anliegens bei den Entwicklern gespeichert wird. Die
+  Angabe einer Mail-Adresse ist freiwillig.
+</p>
+<p>
+  Sentry wird lokal auf Rechnern der Goethe-Universität gehostet; es werden
+  keine Daten nach außen übertragen.
 </p>

--- a/apps/planty/src/app/info-page-content/info-page-content.component.html
+++ b/apps/planty/src/app/info-page-content/info-page-content.component.html
@@ -1,6 +1,5 @@
 <h2>Über die App</h2>
-<p>s.o.l.i.d. Version: {{ solidVersion }}</p>
-<p *ngIf="appVersion !== undefined">PLANTY2Learn Version: {{ appVersion }}</p>
+<p>App Version: {{ appVersion }}</p>
 
 <div class="solid-logo">
   <img alt="Solid Logo" src="assets/info/Solid.svg" />

--- a/apps/planty/src/app/info-page-content/info-page-content.component.ts
+++ b/apps/planty/src/app/info-page-content/info-page-content.component.ts
@@ -1,6 +1,5 @@
 import { Component, Inject } from '@angular/core';
 import { version } from '../../environments/version';
-import pjs from '../../../../../package.json';
 
 import {
   FeedbackService,
@@ -16,8 +15,7 @@ export class InfoPageContentComponent {
   public appVersion =
     version && version.semver && version.semver.version
       ? version.semver.version
-      : undefined;
-  public solidVersion = pjs.version ? pjs.version : 'Version unbekannt';
+      : 'Version unbekannt';
 
   constructor(
     @Inject(SOLID_SKELETON_FEEDBACK_SERVICE) public feedback: FeedbackService

--- a/apps/planty/src/app/privacy/privacy.component.html
+++ b/apps/planty/src/app/privacy/privacy.component.html
@@ -113,7 +113,9 @@ Art der Speicherung keinen unverhältnismäßig hohen Aufwand verursacht.<br />
   Smartphone o.ä.) spezifische, auf das Gerät bezogene Informationen zu
   speichern. Sie dienen zum einem der Benutzerfreundlichkeit von Webseiten (z.B.
   Speicherung von Logindaten). Zum jetzigen Zeitpunkt speichert PLANTY2Learn
-  keine Cookies auf Ihrem Gerät.
+  keine Cookies auf Ihrem Gerät. Cookies werden jedoch im Falle eines
+  technischen Fehlers vom Fehlerüberwachungsdienst Sentry gespeichert (siehe
+  unten).
 </p>
 
 <h4>Lokaler Speicher</h4>
@@ -128,12 +130,19 @@ Art der Speicherung keinen unverhältnismäßig hohen Aufwand verursacht.<br />
 <p>
   Wir verwenden den Dienst Sentry, um die technische Stabilität unserer App
   durch Überwachung der Systemstabilität und Ermittlung von Codefehlern zu
-  verbessern. Sentry dient alleine diesen Zielen und wertet keine Daten zu
-  Werbezwecken aus. Die Daten der Nutzer, wie z.B. Angaben zum Gerät oder
-  Fehlerzeitpunkt werden anonym erhoben und nicht personenbezogen genutzt sowie
-  anschließend gelöscht. Bei Abstürzen ermöglicht Sentry die Eingabe einer
-  Fehlerbeschreibung. Die im Absturzbericht eingegebene E-Mail-Adresse wird zur
-  weiteren Bearbeitung des Anliegens bei den Entwicklern gespeichert.Sentry wird
-  lokal auf Rechnern der Goethe-Universität gehostet; es werden keine Daten nach
-  außen übertragen.
+  verbessern.
+</p>
+<p>
+  Sentry dient alleine diesen Zielen und wertet keine Daten zu Werbezwecken aus.
+  Die Daten der Nutzer, wie z.B. Angaben zum Gerät oder Fehlerzeitpunkt werden
+  anonym erhoben und nicht personenbezogen genutzt sowie anschließend gelöscht.
+  Bei Abstürzen setzt Sentry ein <i>Session-Cookie</i> mit Fehlerinformationen.
+  Zusätzlich erscheint ein Fenster mit der Möglichkeit, eine Fehlerbeschreibung
+  anzugeben. Im Absturzbericht kann eine Mail-Adresse angegeben werden, die zur
+  weiteren Bearbeitung des Anliegens bei den Entwicklern gespeichert wird. Die
+  Angabe einer Mail-Adresse ist freiwillig.
+</p>
+<p>
+  Sentry wird lokal auf Rechnern der Goethe-Universität gehostet; es werden
+  keine Daten nach außen übertragen.
 </p>

--- a/libs/solid/skeleton/src/lib/components/base-layout/base-layout.component.html
+++ b/libs/solid/skeleton/src/lib/components/base-layout/base-layout.component.html
@@ -22,7 +22,7 @@
       </div>
       <div>
         <button (click)="Glossary?.toggle()" mat-icon-button>
-          <mat-icon aria-label="Menü öffnen" svgIcon="glossary"></mat-icon>
+          <mat-icon aria-label="Glossar öffnen" svgIcon="glossary"></mat-icon>
         </button>
       </div>
     </ng-container>
@@ -51,7 +51,7 @@
         <div class="bottom"></div>
       </div>
       <button (click)="Glossary?.toggle(); MainMenu?.close()" mat-icon-button>
-        <mat-icon aria-label="Menü öffnen" svgIcon="glossary"></mat-icon>
+        <mat-icon aria-label="Glossar öffnen" svgIcon="glossary"></mat-icon>
       </button>
     </ng-container>
   </mat-toolbar>


### PR DESCRIPTION
Revert to old version policy established in #1383

Note: Future Frontend-Releases should match the s.o.l.i.d. Version. 

(this is going to be a little weird on dive)

