### PR TITLE
Bb/mineralcompound fix 1

### DIFF
--- a/libs/solid/profile/src/lib/components/detail/detail.component.html
+++ b/libs/solid/profile/src/lib/components/detail/detail.component.html
@@ -205,21 +205,32 @@
       {{ property.title ? property.title : property.key }}
     </p>
     <ng-container *ngSwitchCase="PropertyTypes.String">
-      <p
-        *ngIf="
-          !(profile_obj[property.key]?.indexOf('http') === 0);
-          else httpString
-        "
-        [ngClass]="getClass(level, 'content')"
-      >
-        {{ profile_obj[property.key] }}
-      </p>
-      <ng-template #httpString>
-        <p [ngClass]="getClass(level, 'content')">
-          <a [href]="profile_obj[property.key]" target="_blank">
-            {{ profile_obj[property.key] }}
-          </a>
+      <ng-container *ngIf="property.key !== 'compounds'; else compounds">
+        <p
+          *ngIf="
+            !(profile_obj[property.key]?.indexOf('http') === 0);
+            else httpString
+          "
+          [ngClass]="getClass(level, 'content')"
+        >
+          {{ profile_obj[property.key] }}
         </p>
+        <ng-template #httpString>
+          <p [ngClass]="getClass(level, 'content')">
+            <a [href]="profile_obj[property.key]" target="_blank">
+              {{ profile_obj[property.key] }}
+            </a>
+          </p>
+        </ng-template>
+      </ng-container>
+      <ng-template #compounds>
+        <ng-container *ngFor="let val of profile_obj[property.key]">
+          <p>
+            {{
+              val.name + (val.sub_name !== '' ? ' (' + val.sub_name + ')' : '')
+            }}
+          </p>
+        </ng-container>
       </ng-template>
     </ng-container>
     <p

--- a/libs/solid/profile/src/lib/components/detail/detail.component.ts
+++ b/libs/solid/profile/src/lib/components/detail/detail.component.ts
@@ -148,6 +148,10 @@ export class DetailComponent implements OnInit, OnDestroy {
   }
 
   public shouldDisplayProperty(property: ProfileProperty, profile_obj: any) {
+    // Preliminary workaround to exclude mineraltype_compounds property from rendering
+    if (property.key == 'mineraltype_compounds') {
+      return false;
+    }
     if (property.required) {
       return true;
     }

--- a/libs/solid/profile/src/lib/state/profile.state.ts
+++ b/libs/solid/profile/src/lib/state/profile.state.ts
@@ -119,6 +119,23 @@ export class ProfileState {
     return null;
   }
 
+  // Preliminary Workaround for GeoMat to merge unknown rock compounds with minerals from geomat db
+  private static composeMineralCompounds(
+    compounds: string,
+    geoMatContent: object[]
+  ) {
+    const compundArray = compounds
+      .split(', ')
+      .splice(-geoMatContent.length)
+      .map((value) => ({
+        id: null,
+        name: value,
+        sub_name: '',
+      }));
+    const cmp = [...compundArray, ...geoMatContent];
+    return cmp;
+  }
+
   @Action(LoadProfiles)
   public set(ctx: StateContext<ProfileStateModel>) {
     if (ctx.getState().profiles.length !== 0) {
@@ -140,6 +157,14 @@ export class ProfileState {
                 })
                 .map((profiles: any) => {
                   return profiles[1].map((profile: any) => {
+                    //Preliminary fix for mineral compounds (see function above)
+                    if (profile.composition) {
+                      profile.composition.compounds =
+                        ProfileState.composeMineralCompounds(
+                          profile.composition.compounds,
+                          profile.composition.mineraltype_compounds
+                        );
+                    }
                     const profileName = profile.general_information?.name;
                     const profileSubName =
                       profile.general_information?.sub_name;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zentrumnawi",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "scripts": {
     "ng": "nx",
     "start": "node web-server.js",


### PR DESCRIPTION
This is a preliminary fix for the current GeoMat backend and the new "Stein" model/profile type, which provides a free field for manual entries of mineral compounds as well as an object containing minerals from the GeoMat Mineral database.

It works, but it is not entirely robust and contains a slightly barbaric hack where a string type field is enhanced to an array of objects.

The next step will be to construct active links to the mineral profiles of the GeoMat db (but not to the freely entered compounds).