### PR TITLE
Lkr/guided profile tour 2079

### DIFF
--- a/apps/geomat/src/assets/data/guidedTour.json
+++ b/apps/geomat/src/assets/data/guidedTour.json
@@ -70,8 +70,8 @@
 
   "profile": {
     "location": {
-      "treeNode": "/steckbriefe/tree/100",
-      "profileTree": "/steckbriefe/tree/"
+      "treeNode": "/steckbriefe/mineraltype/100",
+      "profileTree": "/steckbriefe/"
     },
     "steps": [
       {

--- a/apps/planty/src/assets/data/guidedTour.json
+++ b/apps/planty/src/assets/data/guidedTour.json
@@ -64,7 +64,7 @@
   "profile": {
     "location": {
       "treeNode": "/profile/tree/2",
-      "profileTree": "/profile/tree/"
+      "profileTree": "/profile/"
     },
     "steps": [
       {

--- a/libs/solid/profile/src/lib/components/base/base.component.ts
+++ b/libs/solid/profile/src/lib/components/base/base.component.ts
@@ -245,72 +245,74 @@ export class BaseComponent implements OnInit, AfterViewInit, OnDestroy {
     this.calculateLayout();
 
     this.profileSubscription = this.profile$.subscribe((res) => {
-      if(res.length === 0) return;
-      
-      const shouldShowTour =  localStorage.getItem('hide_profile_tour') === 'false' ||
-      localStorage.getItem('hide_profile_tour') === null;
+      if (res.length === 0) return;
+
+      const shouldShowTour =
+        localStorage.getItem('hide_profile_tour') === 'false' ||
+        localStorage.getItem('hide_profile_tour') === null;
       if (shouldShowTour) {
         setTimeout(() => {
           const initialId = this._activatedRoute.snapshot.paramMap.get('id');
-          
+
           this.introService.profileTour((element: HTMLElement) => {
             try {
               this.handleTourStep(element, initialId);
             } catch (error) {
-              console.error('Tour step error:', error);
+              return;
             }
           });
         }, 800);
-    }});
+      }
+    });
   }
-
 
   private async handleTourStep(element: HTMLElement, initialId: string | null) {
     const id = element.id;
-    const { treeNode: treeNodeLocation, profileTree: treeLocation } = 
+    const { treeNode: treeNodeLocation, profileTree: treeLocation } =
       this.coreConfig.profileTour.location;
-    
+
     if (id !== 'profile') {
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       this.refreshTourUI();
     }
-  
+
     if (id === '' && !initialId) {
       this.handleEmptyStep(treeLocation, treeNodeLocation);
     }
-    
+
     // Handle profile view step
     else if ((id === 'profile-view' || id === 'profile') && !initialId) {
       if (this._route.url !== treeLocation) {
         await this.navigateTo(treeLocation);
         this.refreshTourUI();
+        this.collapseTree = true;
       }
     }
-  
+
     this.refreshTourUI();
   }
-  
+
   private refreshTourUI(delay = 400) {
     setTimeout(() => {
       this.introService.introProfile.refresh();
     }, delay);
   }
-  
-  private async handleEmptyStep(treeLocation: string, treeNodeLocation: string) {
+
+  private async handleEmptyStep(
+    treeLocation: string,
+    treeNodeLocation: string,
+  ) {
     if (this._route.url === treeLocation) {
       await this.navigateTo(treeNodeLocation);
     }
-      
-      this.refreshTourUI();
-      
-      const currentStep = this.introService.introProfile.currentStep();
-      if (currentStep) {
-        this.introService.introProfile
-          .start()
-          .goToStep(currentStep + 1)
-      }
+
+    this.refreshTourUI();
+
+    const currentStep = this.introService.introProfile.currentStep();
+    if (currentStep) {
+      this.introService.introProfile.start().goToStep(currentStep + 1);
+    }
   }
-  
 
   public ngOnDestroy(): void {
     this.mainSubscription.unsubscribe();

--- a/libs/solid/profile/src/lib/components/base/base.component.ts
+++ b/libs/solid/profile/src/lib/components/base/base.component.ts
@@ -255,7 +255,6 @@ export class BaseComponent implements OnInit, AfterViewInit, OnDestroy {
           
           this.introService.profileTour((element: HTMLElement) => {
             try {
-              //console.log("this is element", element);
               this.handleTourStep(element, initialId);
             } catch (error) {
               console.error('Tour step error:', error);
@@ -299,8 +298,6 @@ export class BaseComponent implements OnInit, AfterViewInit, OnDestroy {
   
   private async handleEmptyStep(treeLocation: string, treeNodeLocation: string) {
     if (this._route.url === treeLocation) {
-      console.log("navigating to treeNodeLocation", treeNodeLocation);
-    
       await this.navigateTo(treeNodeLocation);
     }
       

--- a/libs/solid/profile/src/lib/services/intro.service.ts
+++ b/libs/solid/profile/src/lib/services/intro.service.ts
@@ -6,7 +6,7 @@ import introJs from 'intro.js';
 
 @Injectable({ providedIn: 'root' })
 export class IntroService {
-  introProfile: any;
+  introProfile!: introJs.IntroJs;
   location: string;
 
   constructor(@Inject(SOLID_CORE_CONFIG) public config: SolidCoreConfig) {
@@ -18,7 +18,7 @@ export class IntroService {
     return new Navigate([url]);
   }
 
-  profileTour(callback: (target: any) => void) {
+  profileTour(callback: (target: HTMLElement) => void) {
     this.introProfile = introJs();
     this.introProfile
       .setOptions({

--- a/libs/solid/profile/tsconfig.lib.json
+++ b/libs/solid/profile/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "target": "ES2022",
     "declaration": true,
     "inlineSources": true,
-    "types": [],
+    "types": ["hammerjs"],
     "lib": ["dom", "es2018"],
     "useDefineForClassFields": false
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zentrumnawi",
-  "version": "4.4.0",
+  "version": "4.3.1",
   "packageManager": "yarn@4.5.3",
   "scripts": {
     "ng": "nx",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,7 @@
     "target": "es5",
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2015", "es2017", "es2018", "dom"],
-    "types": ["node"],
+    "types": ["node", "hammerjs"],
     "paths": {
       "@zentrumnawi/solid-core": ["libs/solid/core/src/index.ts"],
       "@zentrumnawi/solid-glossary": ["libs/solid/glossary/src/index.ts"],


### PR DESCRIPTION
This pull request solves the problem that with the existing design, when navigating to an individual profile as a first interaction with the site, it is not possible to skip or complete the guided tour and at the same time still navigate to the requested profile. With my changes the requested profile is displayed as part of the tour so that if the user interrupts or completes the tour, the right profile is made sure to be visited. The default profile is used for when the tour is triggered without navigating to a particular profile.

Other changes:
- better typing
- refactoring of the tour execution logic for better readability and maintainability
- no editing of tour steps anymore (deleting of steps is not necessary)