### PR TITLE
Add workaround for inconsistent profile data

### DIFF
--- a/libs/solid/profile/src/lib/state/profile.state.ts
+++ b/libs/solid/profile/src/lib/state/profile.state.ts
@@ -152,7 +152,7 @@ export class ProfileState {
         map((response) => {
           const mapit = (input: TreeNodeApi[]): TreeNode[] => {
             return input.map((node: any) => {
-              const multi_profiles = Object.entries(node)
+              let multi_profiles = Object.entries(node)
                 .filter((property: any) => {
                   if (
                     property[0].search('related') !== -1 &&
@@ -180,6 +180,16 @@ export class ProfileState {
                     };
                   });
                 });
+
+              // handle inadvertent case of different types of profiles in the same node
+              if (multi_profiles.length > 1) {
+                multi_profiles = [
+                  multi_profiles.reduce(
+                    (a, b) => (a.length > b.length ? a : b),
+                    [],
+                  ),
+                ];
+              }
 
               return {
                 type: 'category',


### PR DESCRIPTION
There should not be profiles of different types on the same node - it doesn't make sense. But if inadvertently such a faulty profile is added, it should not hinder the display of the legitimate profiles. This is why this workaround checks for the array(s) of profiles and makes sure the largest (that is, the one that contains the legitimate data) is chosen.