### PR TITLE
Lkr/extend glossary

### DIFF
--- a/libs/solid/core/src/lib/solid-core.module.ts
+++ b/libs/solid/core/src/lib/solid-core.module.ts
@@ -24,6 +24,7 @@ import { AudioToolbarComponent } from './components/audio-toolbar/audio-toolbar.
 import { AudioIconComponent } from './components/audio-icon/audio-icon.component';
 import { MEDIA_DIALOG_TOKEN } from './media-dialog-token';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatTabsModule } from '@angular/material/tabs';
 
 @NgModule({
   declarations: [
@@ -48,6 +49,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     ScrollingModule,
     MatSliderModule,
     MatTooltipModule,
+    MatTabsModule,
   ],
   exports: [
     CommonModule,
@@ -58,6 +60,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
     MediaComponent,
     ScrollingModule,
     MatTooltipModule,
+    MatTabsModule,
   ],
   providers: [MarkdownService, TitleService],
 })

--- a/libs/solid/glossary/src/lib/components/glossary.component.html
+++ b/libs/solid/glossary/src/lib/components/glossary.component.html
@@ -5,37 +5,94 @@
     <mat-icon>{{ Filter.value === '' ? 'search' : 'close' }}</mat-icon>
   </button>
 </mat-form-field>
-<div class="scrollable-list">
-  <mat-list *ngIf="GlossaryEntries | async as state">
-    <ng-container *ngFor="let kvp of state.sections">
-      <h3 mat-subeader>{{ kvp[0] }}</h3>
-      <mat-list-item
-        *ngFor="let entryId of kvp[1]"
-        solidGlossaryEntry
-        [refId]="entryId"
-      >
-        <span class="mat-body-strong entry-header" mat-line>{{
-          state.entries[entryId].term
-        }}</span>
-        <div
-          [data]="state.entries[entryId].text"
-          markdown
-          [inline]="true"
-          mat-line
-        ></div>
-        <span
-          class="links"
-          *ngIf="state.entries[entryId].links.length > 0"
-          mat-line
-          >&rarr;<a
-            (click)="followRef(refId)"
-            *ngFor="let refId of state.entries[entryId].links; let i = index"
+
+<div class="scrollable-list" *ngIf="GlossaryEntries | async as state">
+  <!-- Single element case - no tabs needed -->
+  <ng-container *ngIf="Object.keys(state).length === 1">
+    <mat-list>
+      <ng-container *ngFor="let kvp of state['Glossar'].sections">
+        <h3 mat-subeader>{{ kvp[0] }}</h3>
+        <mat-list-item
+          *ngFor="let entryId of kvp[1]"
+          solidGlossaryEntry
+          [refId]="entryId"
+        >
+          <span class="mat-body-strong entry-header" mat-line>{{
+            state['Glossar'].entries[entryId].term
+          }}</span>
+          <div
+            [data]="state['Glossar'].entries[entryId].text"
+            markdown
+            [inline]="true"
+            mat-line
+          ></div>
+          <span
+            class="links"
+            *ngIf="state['Glossar'].entries[entryId].links.length > 0"
+            mat-line
+            >&rarr;<a
+              (click)="followRef(refId)"
+              *ngFor="
+                let refId of state['Glossar'].entries[entryId].links;
+                let i = index
+              "
+            >
+              {{ state['Glossar'].entries[refId].term
+              }}{{
+                i < state['Glossar'].entries[entryId].links.length - 1
+                  ? ','
+                  : ''
+              }}</a
+            >
+          </span>
+        </mat-list-item>
+      </ng-container>
+    </mat-list>
+  </ng-container>
+
+  <!-- Multiple elements case - use tabs -->
+  <mat-tab-group *ngIf="Object.keys(state).length > 1">
+    <mat-tab *ngFor="let tab of Object.keys(state)" [label]="tab">
+      <mat-list>
+        <ng-container *ngFor="let kvp of state[tab].sections">
+          <h3 mat-subeader>{{ kvp[0] }}</h3>
+          <mat-list-item
+            *ngFor="let entryId of kvp[1]"
+            solidGlossaryEntry
+            [refId]="entryId"
           >
-            {{ state.entries[refId].term
-            }}{{ i < state.entries[entryId].links.length - 1 ? ',' : '' }}</a
-          >
-        </span>
-      </mat-list-item>
-    </ng-container>
-  </mat-list>
+            <span class="mat-body-strong entry-header" mat-line>{{
+              state[tab].entries[entryId].term
+            }}</span>
+            <div
+              [data]="state[tab].entries[entryId].text"
+              markdown
+              [inline]="true"
+              mat-line
+            ></div>
+            <span
+              class="links"
+              *ngIf="
+                state[tab].entries[entryId].links.length > 0 &&
+                tab === 'Glossar'
+              "
+              mat-line
+              >&rarr;<a
+                (click)="followRef(refId)"
+                *ngFor="
+                  let refId of state[tab].entries[entryId].links;
+                  let i = index
+                "
+              >
+                {{ state[tab].entries[refId].term
+                }}{{
+                  i < state[tab].entries[entryId].links.length - 1 ? ',' : ''
+                }}
+              </a>
+            </span>
+          </mat-list-item>
+        </ng-container>
+      </mat-list>
+    </mat-tab>
+  </mat-tab-group>
 </div>

--- a/libs/solid/skeleton/src/lib/components/base-layout/base-layout.component.html
+++ b/libs/solid/skeleton/src/lib/components/base-layout/base-layout.component.html
@@ -29,22 +29,11 @@
         <div class="bottom"></div>
       </div>
       <div id="glossary">
-        <button
-          (click)="glossaryType = 'glossary'; Glossary?.toggle()"
-          mat-icon-button
-        >
+        <button (click)="Glossary?.toggle()" mat-icon-button>
           <mat-icon
             aria-label="Glossar öffnen"
             svgIcon="glossary_generic"
           ></mat-icon>
-        </button>
-      </div>
-      <div id="abbreviation" *ngIf="config.appName === 'WABE'">
-        <button
-          (click)="glossaryType = 'abbreviations'; Glossary?.toggle()"
-          mat-icon-button
-        >
-          <mat-icon aria-label="Abkürzungen öffnen" svgIcon="light"></mat-icon>
         </button>
       </div>
     </ng-container>
@@ -138,14 +127,9 @@
         class="glossary-toolbar"
         color="primary"
       >
-        {{ glossaryType === 'glossary' ? 'Glossar' : 'Abkürzungen' }}
+        Glossar
       </mat-toolbar>
-      <ng-container [ngSwitch]="glossaryType">
-        <solid-glossary *ngSwitchCase="'glossary'"></solid-glossary>
-        <solid-abbreviations
-          *ngSwitchCase="'abbreviations'"
-        ></solid-abbreviations>
-      </ng-container>
+      <solid-glossary></solid-glossary>
     </mat-sidenav>
   </mat-sidenav-container>
 </div>

--- a/libs/solid/skeleton/src/lib/components/base-layout/base-layout.component.ts
+++ b/libs/solid/skeleton/src/lib/components/base-layout/base-layout.component.ts
@@ -21,7 +21,6 @@ import { BaseComponent } from '@zentrumnawi/solid-profile';
   styleUrls: ['./base-layout.component.scss'],
 })
 export class BaseLayoutComponent implements OnInit {
-  public glossaryType: 'glossary' | 'abbreviations' = 'glossary';
   public FixedLayout = false;
   public subscription!: Subscription;
   public title = '';


### PR DESCRIPTION
- Adjust state to new structure of API response
- Make sure filtering finds glossary inside API response
- Introduce tabs inside glossary side bar
- Keep old design of glossary side bar when only one tag (= glossary)
- Make functioning of glossary component app-agnostic