### PR TITLE
Take profile type into account

### DIFF
--- a/libs/solid/profile/src/lib/components/grid/grid.component.html
+++ b/libs/solid/profile/src/lib/components/grid/grid.component.html
@@ -18,7 +18,10 @@
     ></ng-container>
   </div>
   <div
-    *ngIf="selectedProfileId !== profile.id"
+    *ngIf="
+      selectedProfileId !== profile.id ||
+      selectedProfileType !== profile.def_type
+    "
     (click)="
       selectProfile.emit({ id: profile.id, type: profile.def_type });
       selectProfileTitle.emit(profile.name)


### PR DESCRIPTION
This solves the bug where in grid view a profile that has the same id as the selected profile but a different def_type is not being displayed. Now this case is covered by extending the condition for which profiles to display.